### PR TITLE
foutieve deling verandert naar een rest deling

### DIFF
--- a/Index/Oefeningen-PP/Hfdst5/BankRekening_controle.md
+++ b/Index/Oefeningen-PP/Hfdst5/BankRekening_controle.md
@@ -1,26 +1,27 @@
 # Oplossing 1
 
 ```csharp
-            Console.Write("Geef de eerste 3 getallen: ");
+            Console.WriteLine("Geef de eerste 3 cijfers van je bankrekeningnummer:");
             string eerste = Console.ReadLine();
 
-            Console.Write("Volgende 7 getallen: ");
+            Console.WriteLine("Geef de volgende 7 cijfers van je bankrekeningnummer:");
             string tweede = Console.ReadLine();
 
-            Console.Write("Laatste 2 getallen; ");
+            Console.WriteLine("Geef de laatste 2 cijfers van je bankrekeningnummer:");
             int laatste = int.Parse(Console.ReadLine());
 
             int eersteTien = Convert.ToInt32(eerste + tweede);
-            int deling = eersteTien / 97;
+            int rest = eersteTien % 97;
 
-            if (deling == laatste )
+
+
+            if (rest == laatste)
             {
-                Console.WriteLine("Je bankrekening is geldig");
+                Console.WriteLine("Het bankrekeningnummer is geldig!");
             }
-
             else
             {
-                Console.WriteLine("Je bankrekening is geldig");
+                Console.WriteLine("Het bankrekeningnummer is niet geldig.");
             }
 ```
 


### PR DESCRIPTION
In de oefening in de cursus staat "Een bankrekeningnummer is geldig als de **rest** van de deling van het getal, dat bestaat uit de eerste 10 cijfers, door 97, gelijk is aan het getal bestaande uit de laatste 2 cijfers."

De oplossing klopte niet, dus heb deze verbeterd en opgeschoond.